### PR TITLE
personalized Welcome modal flow

### DIFF
--- a/client/src/components/WelcomeModal.css
+++ b/client/src/components/WelcomeModal.css
@@ -1,0 +1,51 @@
+.welcome-modal-overlay {
+position: fixed;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+background: rgba(0,0,0,0.5);
+z-index: 999;
+display: flex;
+justify-content: center;
+align-items: center;
+}
+
+.welcome-modal-content {
+background: white;
+padding: 2rem;
+border-radius: 12px;
+width: 90%;
+max-width: 400px;
+text-align: center;
+box-shadow: 0 0 20px rgba(0,0,0,0.15);
+}
+
+.welcome-modal-content h2 {
+color: #A294F9;
+margin-bottom: 0.5rem;
+}
+
+.welcome-modal-content input {
+width: 100%;
+padding: 0.7rem;
+margin-top: 1rem;
+border: 1px solid #ccc;
+border-radius: 8px;
+}
+
+.welcome-modal-content button {
+margin-top: 1.2rem;
+padding: 0.6rem 1.4rem;
+border: none;
+border-radius: 8px;
+background-color: #A294F9;
+color: white;
+font-weight: bold;
+cursor: pointer;
+transition: background 0.3s;
+}
+
+.welcome-modal-content button:hover {
+background-color: #8a79e0;
+}

--- a/client/src/components/WelcomeModal.jsx
+++ b/client/src/components/WelcomeModal.jsx
@@ -1,0 +1,30 @@
+// src/components/WelcomeModal.jsx
+import React, { useState } from 'react';
+import './WelcomeModal.css';
+
+function WelcomeModal({ onSave }) {
+const [name, setName] = useState('');
+
+const handleSubmit = () => {
+if (!name.trim()) return;
+onSave(name.trim());
+};
+
+return (
+<div className="welcome-modal-overlay">
+<div className="welcome-modal-content">
+<h2>Hi there, I’m Bloom 🌷</h2>
+<p>What should I call you?</p>
+<input
+type="text"
+placeholder="Enter your name (e.g., Jen)"
+value={name}
+onChange={(e) => setName(e.target.value)}
+/>
+<button onClick={handleSubmit}>Continue</button>
+</div>
+</div>
+);
+}
+
+export default WelcomeModal;

--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,7 @@ const checkAuth = require('./middleware/checkAuth');
 const habitRoutes = require('./routes/habit');
 const habitLogsRouter = require('./routes/habitLogs');
 const moodsRoutes = require('./routes/moods');
+const userRouter = require('./routes/user');
 
 
 
@@ -46,6 +47,7 @@ app.use('/api', checkAuth, journalRoutes);
 app.use('/api/habits', habitRoutes);
 app.use('/api/habit-logs', habitLogsRouter);
 app.use('/api/moods', moodsRoutes);
+app.use('/api/user', userRouter);
 
 
 

--- a/server/prisma/migrations/20250703213023_add_user_display_fields/migration.sql
+++ b/server/prisma/migrations/20250703213023_add_user_display_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "displayName" TEXT,
+ADD COLUMN     "hasSeenWelcome" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -19,7 +19,9 @@ model User {
   email        String         @unique
   password     String?
   googleId     String?        @unique
-  name         String?
+  name         String?        //full name
+  displayName  String?        //display name for dashboard
+  hasSeenWelcome Boolean      @default(false)
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
 
@@ -27,7 +29,7 @@ model User {
   journalEntries JournalEntry[]
   moods          Mood[]
   habits         Habit[]
-  plantGrowth    PlantGrowth?
+  plantGrowths    PlantGrowth[]
   habitLogs      HabitLog[]
 
 }

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+const checkAuth = require('../middleware/checkAuth');
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+// GET /api/user/me
+router.get('/me', checkAuth, async (req, res) => {
+try {
+const user = await prisma.user.findUnique({
+where: { id: req.userId },
+select: {
+id: true,
+email: true,
+name: true,
+displayName: true,
+hasSeenWelcome: true,
+},
+});
+
+if (!user) return res.status(404).json({ error: 'User not found' });
+
+res.json(user);
+} catch (err) {
+console.error('Error fetching user:', err);
+res.status(500).json({ error: 'Failed to fetch user' });
+}
+});
+
+// PATCH /api/user/profile
+router.patch('/profile', checkAuth, async (req, res) => {
+const { displayName, hasSeenWelcome } = req.body;
+
+try {
+const updatedUser = await prisma.user.update({
+where: { id: req.userId },
+data: {
+...(displayName && { displayName }),
+...(hasSeenWelcome !== undefined && { hasSeenWelcome }),
+},
+select: {
+id: true,
+email: true,
+name: true,
+displayName: true,
+hasSeenWelcome: true,
+},
+});
+
+res.json(updatedUser);
+} catch (err) {
+console.error('Error updating profile:', err);
+res.status(500).json({ error: 'Failed to update profile info' });
+}
+});
+
+module.exports = router;


### PR DESCRIPTION
Previously, when a user logged in, the dashboard showed a static greeting “Hi Jennifer” for every account, regardless of who the user was. This wasn’t personalized and didn’t reflect the actual user’s identity.


To improve this, I implemented a one-time welcome modal that appears only the first time a user logs in after signing up. It prompts the user to enter the name they’d like to be called. Once submitted, that name is saved to the database and used to personalize the dashboard greeting on future visits.

To support this feature:

I modified the Prisma User model to include two new fields: displayName (to store the user’s preferred name) and hasSeenWelcome (a boolean to ensure the modal only appears once).

I created a new WelcomeModal.jsx component and its corresponding CSS file for styling.

I added a new backend route to handle the name submission and update the user’s welcome status.

Logic in the dashboard checks if hasSeenWelcome is false before showing the modal, and updates the UI once the name is set.

