### PR TITLE
feat: implement /api/feed endpoint with pagination

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,8 @@ const userRouter = require('./routes/user');
 const moodLogsRoute = require('./routes/moodLogs');
 const plantGrowthRoutes = require('./routes/plantGrowth');
 const recoRoute = require('./routes/analyticsRecommendation');
+const feedRoutes = require('./routes/feed');
+
 
 app.use('/api/auth', authRoutes);
 app.use('/api/journal', journalRoutes);
@@ -45,6 +47,8 @@ app.use('/api/user', userRouter);
 app.use('/api/mood-logs', moodLogsRoute);
 app.use('/api/plant-growth', plantGrowthRoutes);
 app.use('/api', recoRoute);
+app.use('/api/feed', feedRoutes);
+
 
 
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@faker-js/faker": "^9.9.0",
         "@prisma/client": "^6.10.1",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
@@ -29,6 +28,7 @@
         "socket.io": "^4.8.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.9.0",
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^24.0.3",
@@ -39,6 +39,7 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
       "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,6 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "@faker-js/faker": "^9.9.0",
     "@prisma/client": "^6.10.1",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
@@ -33,6 +32,7 @@
     "socket.io": "^4.8.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.0.3",

--- a/server/prisma/prisma/seedFeed.js
+++ b/server/prisma/prisma/seedFeed.js
@@ -1,0 +1,97 @@
+const { PrismaClient } = require('@prisma/client');
+const { faker } = require('@faker-js/faker');
+
+const prisma = new PrismaClient();
+
+/**
+ * Seeds the database with test data for social feed functionality
+ * Creates two users with a mutual connection and sample activities
+ */
+(async () => {
+  try {
+    // Create or update first test user (Zayo)
+    const userA = await prisma.user.upsert({
+      where: { email: 'zayo@gmail.com' },
+      update: {},
+      create: {
+        email: 'zayo@gmail.com',
+        password: '$2b$10$iwx01S7BGyPYTPTZN2QwOuky3a0VqxwoI/m1DRrvMJjOqwiPDuOEO',
+        name: 'Zayo',
+      },
+    });
+
+    // Create or update second test user (Ball)
+    const userB = await prisma.user.upsert({
+      where: { email: 'ball@gmail.com' },
+      update: {},
+      create: {
+        email: 'ball@gmail.com',
+        password: '$2b$10$qgUYLQfETJf.9i0BZyNBBe281vWY7/quW4pqL0G8Ca598DO1sVstS',
+        name: 'ball',
+      },
+    });
+
+    // Create mutual connection between the two users
+    await prisma.connection.upsert({
+      where: {
+        userAId_userBId: {
+          userAId: userA.id,
+          userBId: userB.id,
+        },
+      },
+      update: {},
+      create: {
+        userAId: userA.id,
+        userBId: userB.id,
+      },
+    });
+
+    // Generate sample mood logs for user B
+    for (let i = 0; i < 3; i++) {
+      await prisma.moodLog.create({
+        data: {
+          mood: faker.number.int({ min: 0, max: 5 }),
+          note: faker.lorem.sentence(),
+          userId: userB.id,
+        },
+      });
+    }
+
+    // Generate sample journal entries for user B
+    for (let i = 0; i < 2; i++) {
+      await prisma.journalEntry.create({
+        data: {
+          title: faker.lorem.words(4),
+          content: faker.lorem.paragraph(),
+          journalMood: faker.number.int({ min: 0, max: 5 }),
+          userId: userB.id,
+        },
+      });
+    }
+
+    // Create a sample habit for user B
+    const habit = await prisma.habit.create({
+      data: {
+        title: 'Meditation',
+        description: '10-minute daily meditation',
+        userId: userB.id,
+      },
+    });
+
+    // Create a completed habit log entry for user B
+    await prisma.habitLog.create({
+      data: {
+        date: new Date('2024-07-12T12:00:00Z'),
+        completed: true,
+        habitId: habit.id,
+        userId: userB.id,
+      },
+    });
+
+    console.log('Seed complete');
+  } catch (err) {
+    console.error('Seed error:', err);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();

--- a/server/routes/feed.js
+++ b/server/routes/feed.js
@@ -1,0 +1,93 @@
+const express = require('express');
+const router = express.Router();
+const checkAuth = require('../middleware/checkAuth');
+const { PrismaClient } = require('@prisma/client');
+const { STATUS } = require('../constants');
+
+const prisma = new PrismaClient();
+const PAGE_LIMIT = 10;
+
+// Main feed endpoint with pagination support
+// GET /api/feed?cursor=ISO8601
+router.get('/', checkAuth, async (req, res) => {
+  const userId = req.userId;
+  const cursor = req.query.cursor
+    ? new Date(req.query.cursor)
+    : new Date(); // Default to current time for first page
+
+  try {
+    // Step 1: Collect mutual connections for the current user
+    const connections = await prisma.$queryRaw`
+      SELECT "userBId" AS id
+      FROM "Connection"
+      WHERE "userAId" = ${userId}
+      UNION
+      SELECT "userAId" AS id
+      FROM "Connection"
+      WHERE "userBId" = ${userId};
+    `;
+
+    const connectionIds = connections.map((c) => c.id);
+
+    // Return empty feed if user has no connections
+    if (connectionIds.length === 0) {
+      return res.status(STATUS.SUCCESS).json({ items: [], nextCursor: null });
+    }
+
+    // Step 2: Fetch privacy settings for all connected users
+    const settings = await prisma.shareSettings.findMany({
+      where: { userId: { in: connectionIds } },
+    });
+
+    // Helper function to check if content should be shown based on privacy settings
+    const canShow = (uid, type) => {
+      const userSettings = settings.find((s) => s.userId === uid);
+      if (!userSettings) return true; // Default to sharing everything if no settings found
+
+      if (type === 'MOOD') return userSettings.shareMood;
+      if (type === 'JOURNAL') return userSettings.shareJournal;
+      if (type === 'HABIT') return userSettings.shareHabit;
+      return false;
+    };
+
+    // Step 3: Execute union query to fetch all feed content types
+    const raw = await prisma.$queryRaw`
+      SELECT * FROM (
+        SELECT id, "userId", 'MOOD' AS type, note AS content, mood AS extra, "createdAt"
+        FROM "MoodLog"
+        WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
+
+        UNION ALL
+
+        SELECT id, "userId", 'JOURNAL' AS type, content, NULL AS extra, "createdAt"
+        FROM "JournalEntry"
+        WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
+
+        UNION ALL
+
+        SELECT HL.id, H."userId", 'HABIT' AS type, H.title AS content, NULL AS extra, HL."date" AS "createdAt"
+        FROM "HabitLog" HL
+        JOIN "Habit" H ON H.id = HL."habitId"
+        WHERE H."userId" = ANY(${connectionIds})
+          AND HL."date" < ${cursor}
+          AND HL."completed" = true
+      ) AS unioned
+      ORDER BY "createdAt" DESC
+      LIMIT ${PAGE_LIMIT + 1};
+    `;
+
+    // Step 4: Filter results based on privacy settings
+    const filtered = raw.filter((item) => canShow(item.userId, item.type));
+
+    // Step 5: Apply pagination and determine next cursor
+    const items = filtered.slice(0, PAGE_LIMIT);
+    const nextCursor = filtered.length > PAGE_LIMIT ? filtered[PAGE_LIMIT].createdAt : null;
+
+    return res.status(STATUS.SUCCESS).json({ items, nextCursor });
+  } catch (error) {
+    console.error('Error loading feed:', error);
+    return res.status(STATUS.SERVER_ERROR).json({ error: 'Failed to load feed' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Add social feed functionality to display activities from connected users

### Files created:
- **feed.js**: Create `/api/feed` endpoint with pagination support
  - Fetches mood logs, journal entries, and completed habits from connections
  - Implements privacy filtering based on user share settings
  - Supports cursor-based pagination for efficient loading

- **seedFeed.js**: Add test data generator for feed functionality
  - Creates sample users with mutual connections
  - Generates test mood logs, journal entries, and habit completions
  - Enables backend route testing and development

### Files modified:

- **index.js**: Register feed routes in server configuration
  - Add `/api/feed` route to main server routing
  - Maintain existing route structure and middleware