### PR TITLE
Tc2 feed cache 2

### DIFF
--- a/server/routes/feed.js
+++ b/server/routes/feed.js
@@ -3,30 +3,44 @@ const router = express.Router();
 const checkAuth = require('../middleware/checkAuth');
 const { PrismaClient } = require('@prisma/client');
 const { STATUS } = require('../constants');
+const cache = require('../utils/cache');
+const { invalidateFeed } = require('../utils/invalidateFeed');
 
 const prisma = new PrismaClient();
 const PAGE_LIMIT = 10;
 
-// Main feed endpoint with pagination support
-// GET /api/feed?cursor=ISO8601
-router.get('/', checkAuth, async (req, res) => {
+/**
+ * Main feed endpoint with pagination support
+ * GET /api/feed?cursor=ISO8601
+ * Returns feed items from user's connections, respecting privacy settings
+ */
+router.get('/', checkAuth, (req, res) => {
   const userId = req.userId;
   const cursor = req.query.cursor
     ? new Date(req.query.cursor)
     : new Date(); // Default to current time for first page
 
-  try {
-    // Step 1: Collect mutual connections for the current user
-    const connections = await prisma.$queryRaw`
-      SELECT "userBId" AS id
-      FROM "Connection"
-      WHERE "userAId" = ${userId}
-      UNION
-      SELECT "userAId" AS id
-      FROM "Connection"
-      WHERE "userBId" = ${userId};
-    `;
+  // Generate cache key based on whether this is first page or paginated request
+  const cacheKey = req.query.cursor
+    ? `feed:${userId}:cursor:${cursor.toISOString()}`
+    : `feed:${userId}:first`;
 
+  // Return cached response if available
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return res.status(STATUS.SUCCESS).json(cached);
+  }
+
+  prisma.$queryRaw`
+    SELECT "userBId" AS id
+    FROM "Connection"
+    WHERE "userAId" = ${userId}
+    UNION
+    SELECT "userAId" AS id
+    FROM "Connection"
+    WHERE "userBId" = ${userId};
+  `
+  .then(connections => {
     const connectionIds = connections.map((c) => c.id);
 
     // Return empty feed if user has no connections
@@ -34,60 +48,65 @@ router.get('/', checkAuth, async (req, res) => {
       return res.status(STATUS.SUCCESS).json({ items: [], nextCursor: null });
     }
 
-    // Step 2: Fetch privacy settings for all connected users
-    const settings = await prisma.shareSettings.findMany({
+    return prisma.shareSettings.findMany({
       where: { userId: { in: connectionIds } },
+    })
+    .then(settings => {
+      // Helper function to check if content should be shown based on privacy settings
+      const canShow = (uid, type) => {
+        const userSettings = settings.find((s) => s.userId === uid);
+        if (!userSettings) return true; // Default to sharing everything if no settings found
+
+        if (type === 'MOOD') return userSettings.shareMood;
+        if (type === 'JOURNAL') return userSettings.shareJournal;
+        if (type === 'HABIT') return userSettings.shareHabit;
+        return false;
+      };
+
+      return prisma.$queryRaw`
+        SELECT * FROM (
+          SELECT id, "userId", 'MOOD' AS type, note AS content, mood AS extra, "createdAt"
+          FROM "MoodLog"
+          WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
+
+          UNION ALL
+
+          SELECT id, "userId", 'JOURNAL' AS type, content, NULL AS extra, "createdAt"
+          FROM "JournalEntry"
+          WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
+
+          UNION ALL
+
+          SELECT HL.id, H."userId", 'HABIT' AS type, H.title AS content, NULL AS extra, HL."date" AS "createdAt"
+          FROM "HabitLog" HL
+          JOIN "Habit" H ON H.id = HL."habitId"
+          WHERE H."userId" = ANY(${connectionIds})
+            AND HL."date" < ${cursor}
+            AND HL."completed" = true
+        ) AS unioned
+        ORDER BY "createdAt" DESC
+        LIMIT ${PAGE_LIMIT + 1};
+      `
+      .then(raw => {
+        // Filter results based on privacy settings
+        const filtered = raw.filter((item) => canShow(item.userId, item.type));
+
+        // Apply pagination and determine next cursor
+        const items = filtered.slice(0, PAGE_LIMIT);
+        const nextCursor = filtered.length > PAGE_LIMIT ? filtered[PAGE_LIMIT].createdAt : null;
+
+        const payload = { items, nextCursor };
+
+        // Store in cache for future requests
+        cache.set(cacheKey, payload);
+
+        return res.status(STATUS.SUCCESS).json(payload);
+      });
     });
-
-    // Helper function to check if content should be shown based on privacy settings
-    const canShow = (uid, type) => {
-      const userSettings = settings.find((s) => s.userId === uid);
-      if (!userSettings) return true; // Default to sharing everything if no settings found
-
-      if (type === 'MOOD') return userSettings.shareMood;
-      if (type === 'JOURNAL') return userSettings.shareJournal;
-      if (type === 'HABIT') return userSettings.shareHabit;
-      return false;
-    };
-
-    // Step 3: Execute union query to fetch all feed content types
-    const raw = await prisma.$queryRaw`
-      SELECT * FROM (
-        SELECT id, "userId", 'MOOD' AS type, note AS content, mood AS extra, "createdAt"
-        FROM "MoodLog"
-        WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
-
-        UNION ALL
-
-        SELECT id, "userId", 'JOURNAL' AS type, content, NULL AS extra, "createdAt"
-        FROM "JournalEntry"
-        WHERE "userId" = ANY(${connectionIds}) AND "createdAt" < ${cursor}
-
-        UNION ALL
-
-        SELECT HL.id, H."userId", 'HABIT' AS type, H.title AS content, NULL AS extra, HL."date" AS "createdAt"
-        FROM "HabitLog" HL
-        JOIN "Habit" H ON H.id = HL."habitId"
-        WHERE H."userId" = ANY(${connectionIds})
-          AND HL."date" < ${cursor}
-          AND HL."completed" = true
-      ) AS unioned
-      ORDER BY "createdAt" DESC
-      LIMIT ${PAGE_LIMIT + 1};
-    `;
-
-    // Step 4: Filter results based on privacy settings
-    const filtered = raw.filter((item) => canShow(item.userId, item.type));
-
-    // Step 5: Apply pagination and determine next cursor
-    const items = filtered.slice(0, PAGE_LIMIT);
-    const nextCursor = filtered.length > PAGE_LIMIT ? filtered[PAGE_LIMIT].createdAt : null;
-
-    return res.status(STATUS.SUCCESS).json({ items, nextCursor });
-  } catch (error) {
-    console.error('Error loading feed:', error);
+  })
+  .catch(() => {
     return res.status(STATUS.SERVER_ERROR).json({ error: 'Failed to load feed' });
-  }
+  });
 });
 
 module.exports = router;

--- a/server/routes/journal.js
+++ b/server/routes/journal.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { PrismaClient } = require('@prisma/client');
 const checkAuth = require('../middleware/checkAuth');
 const { STATUS } = require('../constants');
+const { invalidateFeed } = require('../utils/invalidateFeed');
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -29,20 +30,39 @@ router.get('/', async (req, res) => {
 // POST /api/journal - Create a new journal entry
 router.post('/', (req, res) => {
   const { content, title, journalMood } = req.body;
+  const userId = req.userId;
 
-  prisma.journalEntry
-    .create({
-      data: {
-        title: title || 'Untitled Entry',
-        content,
-        journalMood,
-        userId: req.userId,
-      },
-    })
-    .then((entry) => res.json(entry))
-    .catch(() =>
-      res.status(STATUS.SERVER_ERROR).json({ message: 'Error creating entry' })
-    );
+  prisma.journalEntry.create({
+    data: {
+      title: title || 'Untitled Entry',
+      content,
+      journalMood,
+      userId,
+    },
+  })
+  .then(entry => {
+    // Get user's connections to invalidate their feed caches
+    return prisma.$queryRaw`
+      SELECT "userBId" AS id
+      FROM "Connection"
+      WHERE "userAId" = ${userId}
+      UNION
+      SELECT "userAId" AS id
+      FROM "Connection"
+      WHERE "userBId" = ${userId};
+    `
+    .then(connections => {
+      const connectionIds = connections.map((c) => c.id);
+
+      // Invalidate feed caches
+      invalidateFeed(userId, connectionIds);
+
+      return res.json(entry);
+    });
+  })
+  .catch(() => {
+    return res.status(STATUS.SERVER_ERROR).json({ message: 'Error creating entry' });
+  });
 });
 
 
@@ -68,32 +88,69 @@ router.get('/:id', (req, res) => {
 // PUT /api/journal/:id - Update a journal entry
 router.put('/:id', (req, res) => {
   const { content, title, journalMood } = req.body;
+  const userId = req.userId;
 
-  prisma.journalEntry
-    .update({
-      where: { id: req.params.id },
-      data: {
-        ...(title && { title }),
-        ...(content && { content }),
-        ...(journalMood !== undefined && { journalMood }),
-      },
-    })
-    .then((updatedEntry) => res.json(updatedEntry))
-    .catch(() =>
-      res.status(STATUS.SERVER_ERROR).json({ message: 'Error updating entry' })
-    );
+  prisma.journalEntry.update({
+    where: { id: req.params.id },
+    data: {
+      ...(title && { title }),
+      ...(content && { content }),
+      ...(journalMood !== undefined && { journalMood }),
+    },
+  })
+  .then(updatedEntry => {
+    // Get user's connections to invalidate their feed caches
+    return prisma.$queryRaw`
+      SELECT "userBId" AS id
+      FROM "Connection"
+      WHERE "userAId" = ${userId}
+      UNION
+      SELECT "userAId" AS id
+      FROM "Connection"
+      WHERE "userBId" = ${userId};
+    `
+    .then(connections => {
+      const connectionIds = connections.map((c) => c.id);
+
+      // Invalidate feed caches
+      invalidateFeed(userId, connectionIds);
+
+      return res.json(updatedEntry);
+    });
+  })
+  .catch(() => {
+    return res.status(STATUS.SERVER_ERROR).json({ message: 'Error updating entry' });
+  });
 });
 
 // DELETE /api/journal/:id - Delete journal entry
 router.delete('/:id', (req, res) => {
-  prisma.journalEntry
-    .delete({ where: { id: req.params.id } })
-    .then(() =>
-      res.json({ message: 'Entry deleted successfully' })
-    )
-    .catch(() =>
-      res.status(STATUS.SERVER_ERROR).json({ message: 'Error deleting entry' })
-    );
+  const userId = req.userId;
+
+  prisma.journalEntry.delete({ where: { id: req.params.id } })
+  .then(() => {
+    // Get user's connections to invalidate their feed caches
+    return prisma.$queryRaw`
+      SELECT "userBId" AS id
+      FROM "Connection"
+      WHERE "userAId" = ${userId}
+      UNION
+      SELECT "userAId" AS id
+      FROM "Connection"
+      WHERE "userBId" = ${userId};
+    `
+    .then(connections => {
+      const connectionIds = connections.map((c) => c.id);
+
+      // Invalidate feed caches
+      invalidateFeed(userId, connectionIds);
+
+      return res.json({ message: 'Entry deleted successfully' });
+    });
+  })
+  .catch(() => {
+    return res.status(STATUS.SERVER_ERROR).json({ message: 'Error deleting entry' });
+  });
 });
 
 module.exports = router;

--- a/server/routes/moodLogs.js
+++ b/server/routes/moodLogs.js
@@ -3,6 +3,7 @@ const express = require('express');
 const { PrismaClient } = require('@prisma/client');
 const checkAuth = require('../middleware/checkAuth');
 const { STATUS } = require('../constants');
+const { invalidateFeed } = require('../utils/invalidateFeed');
 
 const router = express.Router();
 const prisma = new PrismaClient();
@@ -24,59 +25,75 @@ router.post('/', (req, res) => {
   const startOfDay = new Date();
   startOfDay.setHours(0, 0, 0, 0);
 
-  prisma.moodLog
-    .findFirst({
-      where: {
-        userId,
-        createdAt: { gte: startOfDay },
+  prisma.moodLog.findFirst({
+    where: {
+      userId,
+      createdAt: { gte: startOfDay },
+    },
+  })
+  .then(existingMood => {
+    if (existingMood) {
+      return res
+        .status(STATUS.BAD_REQUEST)
+        .json({ error: "You've already checked in today" });
+    }
+
+    // Create new mood log
+    return prisma.moodLog.create({
+      data: {
+        mood,
+        note,
+        user: { connect: { id: userId } },
       },
     })
-    .then((existingMood) => {
-      if (existingMood) {
-        return res
-          .status(STATUS.BAD_REQUEST)
-          .json({ error: "You've already checked in today" });
-      }
+    .then(newMoodLog => {
+      // Get user's connections to invalidate their feed caches
+      return prisma.$queryRaw`
+        SELECT "userBId" AS id
+        FROM "Connection"
+        WHERE "userAId" = ${userId}
+        UNION
+        SELECT "userAId" AS id
+        FROM "Connection"
+        WHERE "userBId" = ${userId};
+      `
+      .then(connections => {
+        const connectionIds = connections.map((c) => c.id);
 
-      // Create new mood log
-      return prisma.moodLog.create({
-        data: {
-          mood,
-          note,
-          user: { connect: { id: userId } },
-        },
+        // Invalidate feed caches
+        invalidateFeed(userId, connectionIds);
+
+        return res.status(STATUS.SUCCESS).json(newMoodLog);
       });
-    })
-    .then((newMoodLog) => {
-      if (newMoodLog) res.status(STATUS.SUCCESS).json(newMoodLog);
-    })
-    .catch(() =>
-      res.status(STATUS.SERVER_ERROR).json({ error: 'Failed to create mood log' })
-    );
+    });
+  })
+  .catch(() => {
+    return res.status(STATUS.SERVER_ERROR).json({ error: 'Failed to create mood log' });
+  });
 });
 
 // GET /api/mood-logs/today
-router.get('/today', async (req, res) => {
-  try {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+router.get('/today', (req, res) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
-    const mood = await prisma.moodLog.findFirst({
-      where: {
-        userId: req.userId,
-        createdAt: {
-          gte: today
-        }
-      },
-      orderBy: {
-        createdAt: 'desc'
+  prisma.moodLog.findFirst({
+    where: {
+      userId: req.userId,
+      createdAt: {
+        gte: today
       }
-    });
-
-    res.json(mood || null);
-  } catch {
-    res.status(500).json({ error: 'Failed to fetch mood log' });
-  }
+    },
+    orderBy: {
+      createdAt: 'desc'
+    }
+  })
+  .then(mood => {
+    return res.json(mood || null);
+  })
+  .catch(() => {
+    return res.status(STATUS.SERVER_ERROR).json({ error: 'Failed to fetch mood log' });
+  });
 });
 
 // GET /api/mood-logs

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -1,0 +1,109 @@
+// Custom LRU Cache Implementation
+// A simple in-memory cache with LRU eviction policy and TTL support
+
+class CustomCache {
+  constructor(options = {}) {
+    this.maxSize = options.max || 1000;
+    this.defaultTTL = options.ttl || 300000; // 5 minutes in milliseconds
+    this.cache = new Map();
+    this.accessOrder = []; // Track LRU order
+  }
+
+  // Get a value from the cache
+  // Returns the cached value or undefined if not found/expired
+  get(key) {
+    const item = this.cache.get(key);
+    if (!item) {
+      return undefined;
+    }
+
+    // Check if the item has expired
+    if (item.expiry && Date.now() > item.expiry) {
+      this.delete(key);
+      return undefined;
+    }
+
+    // Update access order for LRU
+    this._updateAccessOrder(key);
+    return item.value;
+  }
+
+  // Set a value in the cache with optional TTL
+  set(key, value, ttl = this.defaultTTL) {
+    // Evict if at capacity and this is a new key
+    if (this.cache.size >= this.maxSize && !this.cache.has(key)) {
+      this._evictLRU();
+    }
+
+    const expiry = ttl ? Date.now() + ttl : null;
+    this.cache.set(key, { value, expiry });
+    this._updateAccessOrder(key);
+    return true;
+  }
+
+  // Delete a value from the cache
+  // Supports wildcard deletion with * at the end of key
+  delete(key) {
+    // Support for wildcard deletion (e.g., "feed:123:cursor:*")
+    if (key.endsWith('*')) {
+      const prefix = key.slice(0, -1);
+      let deleted = false;
+
+      for (const cacheKey of this.cache.keys()) {
+        if (cacheKey.startsWith(prefix)) {
+          this._removeFromAccessOrder(cacheKey);
+          this.cache.delete(cacheKey);
+          deleted = true;
+        }
+      }
+
+      return deleted;
+    }
+
+    // Standard key deletion
+    const deleted = this.cache.delete(key);
+    if (deleted) {
+      this._removeFromAccessOrder(key);
+    }
+    return deleted;
+  }
+
+  // Clear the entire cache
+  clear() {
+    this.cache.clear();
+    this.accessOrder = [];
+  }
+
+  // Get the current size of the cache
+  size() {
+    return this.cache.size;
+  }
+
+  // Update the access order for LRU tracking
+  _updateAccessOrder(key) {
+    this._removeFromAccessOrder(key);
+    this.accessOrder.push(key);
+  }
+
+  // Remove a key from the access order array
+  _removeFromAccessOrder(key) {
+    const index = this.accessOrder.indexOf(key);
+    if (index > -1) {
+      this.accessOrder.splice(index, 1);
+    }
+  }
+
+  // Evict the least recently used item
+  _evictLRU() {
+    if (this.accessOrder.length > 0) {
+      const oldest = this.accessOrder.shift();
+      this.cache.delete(oldest);
+    }
+  }
+}
+
+// Export a singleton instance with desired configuration
+module.exports = new CustomCache({
+  max: 1000, // Maximum number of items in cache
+  ttl: 300000 // 5 minutes TTL for each entry
+});

--- a/server/utils/invalidateFeed.js
+++ b/server/utils/invalidateFeed.js
@@ -1,0 +1,13 @@
+const cache = require('./cache');
+
+module.exports.invalidateFeed = (userId, connectionIds) => {
+  // clear this user's own cache
+  cache.delete(`feed:${userId}:first`);
+  cache.delete(`feed:${userId}:cursor:*`);
+
+  // clear for each connection
+  connectionIds.forEach(id => {
+    cache.delete(`feed:${id}:first`);
+    cache.delete(`feed:${id}:cursor:*`);
+  });
+};


### PR DESCRIPTION
**New Files**

*   **[`cache.js`](command:code-compose.open?%5B%22%2Fserver%2Futils%2Fcache.js%22%2Cnull%5D "/server/utils/cache.js")**: Created a custom LRU cache implementation with TTL support and wildcard deletion to instead of using the external lru-cache library.
    
*   **[`invalidateFeed.js`](command:code-compose.open?%5B%22%2Fserver%2Futils%2FinvalidateFeed.js%22%2Cnull%5D "/server/utils/invalidateFeed.js")**: Added utility to invalidate feed caches for both users and their connections when data changes.
    

**Modified Files**

*   **[`feed.js`] Improved cache key generation by replacing `cursor === new Date()` comparison with `req.query.cursor` existence check for better pagination handling.
    
*   **[`journal.js`](command:code-compose.open?%5B%22%2Fserver%2Froutes%2Fjournal.js%22%2Cnull%5D "/server/routes/journal.js")**: Converted async/await syntax to .then/.catch pattern and added proper cache invalidation for CRUD operations.
    
*   **[`moodLogs.js*](command:code-compose.open?%5B%22%2Fserver%2Froutes%2FmoodLogs.js%22%2Cnull%5D "/server/routes/moodLogs.js")**: Standardized error handling with .then/.catch pattern and implemented cache invalidation when creating mood logs.
    
*   **[`habit.js`](command:code-compose.open?%5B%22%2Fserver%2Froutes%2Fhabit.js%22%2Cnull%5D "/server/routes/habit.js")**: Converted to .then/.catch pattern for consistency and added cache invalidation for habit CRUD operations.
    
*   **[`habitLogs.js`](command:code-compose.open?%5B%22%2Fserver%2Froutes%2FhabitLogs.js%22%2Cnull%5D "/server/routes/habitLogs.js")**: Implemented .then/.catch pattern and added cache invalidation when creating or updating habit logs.