### PR TITLE
Fix journal entry timestamp update

### DIFF
--- a/client/src/components/Journal.css
+++ b/client/src/components/Journal.css
@@ -176,6 +176,12 @@
   font-size: 1.5rem;
 }
 
+.entry-dates {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .entry-date {
   margin: 0;
   color: #7f8c8d;

--- a/client/src/components/JournalEntry.jsx
+++ b/client/src/components/JournalEntry.jsx
@@ -27,6 +27,9 @@ function JournalEntry({ entry, onEdit, onDelete }) {
     });
   };
 
+  // Check if the entry has been updated after creation
+  const hasBeenEdited = new Date(entry.updatedAt).getTime() > new Date(entry.createdAt).getTime();
+
   return (
     <div className="journal-entry panel">
       <div className="entry-header">
@@ -35,7 +38,10 @@ function JournalEntry({ entry, onEdit, onDelete }) {
             <span className="entry-mood">{getMoodEmoji(entry.mood?.value)}</span>
             {entry.title}
           </h3>
-          <p className="entry-date">{formatDate(entry.createdAt)}</p>
+          <div className="entry-dates">
+            <p className="entry-date">Created: {formatDate(entry.createdAt)}</p>
+            {hasBeenEdited && <p className="entry-date">Last edited: {formatDate(entry.updatedAt)}</p>}
+          </div>
         </div>
         <div className="entry-actions">
           <button

--- a/server/prisma/migrations/20250718223819_update_journal_entry_timestamp/migration.sql
+++ b/server/prisma/migrations/20250718223819_update_journal_entry_timestamp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "JournalEntry" ALTER COLUMN "updatedAt" DROP DEFAULT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -60,7 +60,7 @@ model JournalEntry {
   content   String
   journalMood  Int?     // 0-5 scale for emoji, not tied to MoodLog
   createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   //Relationships
   userId String


### PR DESCRIPTION
**Problem**

Journal entry timestamps were not updating when entries were edited. This was because the `updatedAt` field in the JournalEntry model was using `@default(now())` instead of the Prisma `@updatedAt` directive, so it was only set when entries were created but not updated on edits.

**Changes Made**

**Files Modified:**

1.  **Database Schema Fix**:
    **schema.prisma**: Changed the JournalEntry model's `updatedAt` field from `@default(now())` to `@updatedAt`
   
2.  **UI Enhancement**:
    
    **JournalEntry.jsx**: Updated to display both creation and last edit timestamps
    **Journal.css**: Added styling for the new timestamp display

**Result**

When journal entries are edited, the `updatedAt` timestamp now automatically updates in the database, and the UI clearly shows both the original creation time and the last edit time.

**Demo:**
https://drive.google.com/file/d/1cXY-vV4D56S1dYX6EPTIhazYG93CSt3W/view?usp=drive_link