### PR TITLE
Add view all mood logs modal

### DIFF
--- a/client/src/components/MoodLogsModal.css
+++ b/client/src/components/MoodLogsModal.css
@@ -1,5 +1,3 @@
-/* Additional styles for the mood logs modal */
-
 .mood-logs-modal {
   max-width: 500px;
   max-height: 80vh;

--- a/client/src/components/MoodLogsModal.css
+++ b/client/src/components/MoodLogsModal.css
@@ -1,0 +1,87 @@
+/* Additional styles for the mood logs modal */
+
+.mood-logs-modal {
+  max-width: 500px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.mood-logs-container {
+  max-height: 400px;
+  overflow-y: auto;
+  margin: 15px 0;
+  padding-right: 10px;
+  /* Custom scrollbar for better UX */
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent) transparent;
+}
+
+.mood-logs-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.mood-logs-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.mood-logs-container::-webkit-scrollbar-thumb {
+  background-color: var(--accent);
+  border-radius: 10px;
+}
+
+.mood-log-item {
+  display: flex;
+  align-items: flex-start;
+  padding: 12px;
+  margin-bottom: 10px;
+  background: var(--input-bg);
+  border-radius: 10px;
+  border-left: 4px solid var(--accent);
+  transition: transform 0.2s ease;
+}
+
+.mood-log-item:hover {
+  transform: translateX(2px);
+}
+
+.mood-log-emoji {
+  font-size: 24px;
+  margin-right: 15px;
+  min-width: 30px;
+  text-align: center;
+}
+
+.mood-log-details {
+  flex: 1;
+}
+
+.mood-log-date {
+  font-weight: 500;
+  margin-bottom: 4px;
+  color: var(--fg);
+}
+
+.mood-log-note {
+  font-size: 14px;
+  color: var(--fg-muted, #666);
+  line-height: 1.4;
+}
+
+.loading, .error, .empty-state {
+  padding: 20px;
+  text-align: center;
+  color: var(--fg-muted, #666);
+}
+
+.error {
+  color: var(--error, #e74c3c);
+}
+
+.empty-state {
+  padding: 30px 0;
+}
+
+.empty-state p {
+  margin: 8px 0;
+}

--- a/client/src/components/MoodLogsModal.jsx
+++ b/client/src/components/MoodLogsModal.jsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+import axios from '../api/axiosInstance';
+import './MoodModal.css';
+import './MoodLogsModal.css';
+
+function MoodLogsModal({ onClose }) {
+  const [moodLogs, setMoodLogs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Fetch mood logs for the current week
+  useEffect(() => {
+    const fetchWeeklyMoodLogs = async () => {
+      try {
+        // Calculate the start of the current week (Sunday)
+        const today = new Date();
+        const dayOfWeek = today.getDay(); // 0 is Sunday, 1 is Monday, etc.
+        const startOfWeek = new Date(today);
+        startOfWeek.setDate(today.getDate() - dayOfWeek);
+        startOfWeek.setHours(0, 0, 0, 0);
+
+        // Fetch mood logs from the start of the week
+        const response = await axios.get(`/api/mood-logs?from=${startOfWeek.toISOString()}`);
+        setMoodLogs(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError('Failed to load mood logs. Please try again.');
+        setLoading(false);
+      }
+    };
+
+    fetchWeeklyMoodLogs();
+  }, []);
+
+  // Convert mood value (1-5) into matching emoji
+  const getMoodEmoji = (value) => {
+    const moodMap = {
+      1: '😢', // Sad
+      2: '😐', // Neutral
+      3: '😊', // Content
+      4: '😁', // Happy
+      5: '😄', // Excited
+    };
+    return moodMap[value] || '🙂';
+  };
+
+  // Format date to display day and time
+  const formatDate = (dateString) => {
+    const date = new Date(dateString);
+    const options = {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    };
+    return date.toLocaleDateString('en-US', options);
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <div className="mood-modal mood-logs-modal">
+        <h2>This Week's Mood Logs</h2>
+
+        {loading ? (
+          <div className="loading">Loading mood logs...</div>
+        ) : error ? (
+          <div className="error">{error}</div>
+        ) : moodLogs.length === 0 ? (
+          <div className="empty-state">
+            <p>No mood logs recorded this week.</p>
+            <p>Start logging your mood daily to see your entries here!</p>
+          </div>
+        ) : (
+          <div className="mood-logs-container">
+            {moodLogs.map((log) => (
+              <div key={log.id} className="mood-log-item">
+                <div className="mood-log-emoji">{getMoodEmoji(log.mood)}</div>
+                <div className="mood-log-details">
+                  <div className="mood-log-date">{formatDate(log.createdAt)}</div>
+                  {log.note && <div className="mood-log-note">{log.note}</div>}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="modal-actions">
+          <button className="submit-button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MoodLogsModal;

--- a/client/src/pages/DashBoardHome.jsx
+++ b/client/src/pages/DashBoardHome.jsx
@@ -4,6 +4,7 @@ import axios from '../api/axiosInstance';
 import toast from 'react-hot-toast';
 import WelcomeModal from '../components/WelcomeModal';
 import MoodModal from '../components/MoodModal';
+import MoodLogsModal from '../components/MoodLogsModal';
 import PlantGrid from '../components/PlantGrid';
 import { checkAndGrowPlant } from '../services/plantService';
 import { calculateMoodStreak } from './MoodPage';
@@ -32,6 +33,7 @@ function DashBoardHome() {
   const [hasSeenWelcome, setHasSeenWelcome] = useState(false);
   const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [showMoodModal, setShowMoodModal] = useState(false);
+  const [showMoodLogsModal, setShowMoodLogsModal] = useState(false);
 
   // State for dashboard data
   const [todayMood, setTodayMood] = useState(null);
@@ -230,8 +232,11 @@ function DashBoardHome() {
       <section className="dashboard-section grid-two">
         <div className="card mood-card">
           <div className="card-header">
-            <h3>This Week’s Mood</h3>
-            <a href="#">View All</a>
+            <h3>This Week's Mood</h3>
+            <a href="#" onClick={(e) => {
+              e.preventDefault();
+              setShowMoodLogsModal(true);
+            }}>View All</a>
           </div>
           <p className="mood-text">
             {todayMood
@@ -338,6 +343,7 @@ function DashBoardHome() {
       </section>
 
       {showWelcomeModal && <WelcomeModal onSave={handleSaveDisplayName} />}
+      {showMoodLogsModal && <MoodLogsModal onClose={() => setShowMoodLogsModal(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
**Problem**

The "View All" link in the "This Week's Mood" section on the dashboard home page wasn't functional. When clicked, it didn't display anything, preventing users from seeing a view of their mood logs for the week.

**Changes Made**

1.  **Created a new modal component**:
    
    *   Added `MoodLogsModal.jsx` that fetches and displays all mood logs for the current week
    *   Implemented proper loading states, error handling, and empty state messaging
    *   Added formatted date display and emoji representation for each mood log
2.  **Added styling for the modal**:
    
    *   Created `MoodLogsModal.css` with responsive design for the modal
    *   Implemented a scrollable container for viewing multiple mood logs
    *   Added visual enhancements like custom scrollbars and hover effects
    *   Ensured consistent styling with the app's design system
3.  **Connected the modal to the dashboard**:
    
    *   Updated `DashBoardHome.jsx` to import and use the new modal component
    *   Added state management to control the modal's visibility
    *   Connected the "View All" link to toggle the modal display
    *   Ensured the modal could be properly closed

**Result**


Users can now click the "View All" link in the mood section to see a comprehensive, scrollable list of all their mood logs for the current week, complete with dates, emojis, and any notes they've added.

**Demo**

https://drive.google.com/file/d/1E2_Pb9dUv73yMfANIeL0BTOR9ZfuDRt4/view?usp=sharing