### PR TITLE
Minor bugs

### DIFF
--- a/client/src/components/JournalSearch.jsx
+++ b/client/src/components/JournalSearch.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { moodOptions, moodMap } from '../utils/moodUtils';
+import { journalMoodOptions, journalMoodMap } from '../utils/journalMoodUtils';
 import './JournalSearch.css';
 
 function JournalSearch({ onSearch }) {
@@ -118,14 +118,14 @@ function JournalSearch({ onSearch }) {
             <div className="search-field mood-filter">
               <label>Filter by mood:</label>
               <div className="mood-filter-options">
-                {moodOptions.map((mood) => (
+                {journalMoodOptions.map((mood) => (
                   <label key={mood.value} className="mood-filter-option">
                     <input
                       type="radio"
                       name="moodFilter"
-                      value={moodMap[mood.value]}
-                      checked={selectedMood === moodMap[mood.value].toString()}
-                      onChange={() => setSelectedMood(moodMap[mood.value].toString())}
+                      value={journalMoodMap[mood.value]}
+                      checked={selectedMood === journalMoodMap[mood.value].toString()}
+                      onChange={() => setSelectedMood(journalMoodMap[mood.value].toString())}
                     />
                     <span className="mood-filter-label">
                       <span className="mood-emoji">{mood.emoji}</span> {mood.label}


### PR DESCRIPTION
I noticed that habit streaks weren't properly resetting when users missed days of using the app.

**What was happening:**

*   If a user toggled a habit after missing days, the streak would continue from where it left off instead of resetting to 0
*   The streak counter only incremented when a habit was completed, but didn't check for missed days in between

**The issue:**

*   The streak logic only evaluated when a user actively interacted with a habit
*   If a user didn't open the app for several days, then returned and completed a habit, the streak would incorrectly continue

**Fix:**

1.  Added a new [`**verify-streaks**`](command:code-compose.open?%5B%22%2Fapi%2Fhabits%2Fverify-streaks%22%2Cnull%5D "/api/habits/verify-streaks") endpoint in [`**habit.js**`](command:code-compose.open?%5B%22%2FUsers%2Fjennobi%2Fcodepath%2FMeta-University-Capstone%2Fserver%2Froutes%2Fhabit.js%22%2Cnull%5D "habit.js") that:
    
    *   Retrieves each habit's most recent completed log
    *   Calculates days since last completion
    *   Resets streak to 0 if more than one day has passed
2.  Modified the `HabitList.jsx` component to:
    
    *   Call this endpoint when loading the habits page
    *   Use the returned habits with corrected streak values